### PR TITLE
Bump up ruby versions and gem_rbs_collection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 3.x
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 3
+    - name: Set up Ruby 3.x
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3
         bundler-cache: true
     - name: Install gem_rbs_collection
       run: bundle exec rbs collection install

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,25 +1,12 @@
 ---
-sources:
-- name: ruby/gem_rbs_collection
-  remote: https://github.com/ruby/gem_rbs_collection.git
-  revision: main
-  repo_dir: gems
 path: ".gem_rbs_collection"
 gems:
-- name: faraday
-  version: '2.5'
+- name: addressable
+  version: '2.8'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: activesupport
-  version: '7.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -27,50 +14,54 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: concurrent-ruby
-  version: '1.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: csv
+- name: bigdecimal
   version: '0'
   source:
     type: stdlib
+- name: faraday
+  version: '2.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: fileutils
   version: '0'
   source:
     type: stdlib
-- name: i18n
-  version: '1.10'
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
+- name: hashdiff
+  version: '1.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
   version: '0'
   source:
     type: stdlib
-- name: listen
-  version: '3.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: logger
+- name: minitest
   version: '0'
   source:
     type: stdlib
-- name: minitest
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: net-http
+  version: '0'
+  source:
+    type: stdlib
+- name: net-protocol
   version: '0'
   source:
     type: stdlib
@@ -79,7 +70,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -87,14 +86,42 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9612e5e67697153dcc7464c01115db44d29b1e34
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: securerandom
-  version: '0'
+- name: rake
+  version: '13.0'
   source:
-    type: stdlib
-- name: strscan
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: regexp_parser
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop
+  version: '1.57'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop-ast
+  version: '1.30'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: timeout
   version: '0'
   source:
     type: stdlib
@@ -102,28 +129,12 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: forwardable
-  version: '0'
+- name: webmock
+  version: '3.19'
   source:
-    type: stdlib
-- name: date
-  version: '0'
-  source:
-    type: stdlib
-- name: monitor
-  version: '0'
-  source:
-    type: stdlib
-- name: mutex_m
-  version: '0'
-  source:
-    type: stdlib
-- name: singleton
-  version: '0'
-  source:
-    type: stdlib
-- name: time
-  version: '0'
-  source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 823e015090cd291d53c4f9d9d7e76b931a6cc75d
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
- Run `rbs collection update`.
- Bump up ruby versions on CI.
  - Removed Ruby `2.x` from target version.
  - Add `3.3` to target version.
